### PR TITLE
refactor(cmd): centralize command registration to fix duplicate serve command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"embed"
+
 	"github.com/spf13/cobra"
 )
 
@@ -31,4 +32,5 @@ func init() {
 	rootCmd.AddCommand(networkCmd)
 	rootCmd.AddCommand(storageCmd)
 	rootCmd.AddCommand(imageCmd)
+	rootCmd.AddCommand(apiKeyCmd)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,6 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
 	"github.com/ccheshirecat/flint/pkg/config"
 	"github.com/ccheshirecat/flint/pkg/core"
 	"github.com/ccheshirecat/flint/pkg/libvirtclient"
@@ -15,10 +20,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
-	"log"
-	"os"
-	"path/filepath"
-	"runtime"
 )
 
 // dummyClient implements ClientInterface but returns errors for all operations
@@ -485,9 +486,6 @@ WARNING: Keep this key secure and do not share it publicly.`,
 }
 
 func init() {
-	rootCmd.AddCommand(serveCmd)
-	rootCmd.AddCommand(apiKeyCmd)
-
 	// Add flags specific to the server
 	serveCmd.Flags().StringVar(&passphraseFlag, "passphrase", "", "Web UI passphrase (will be hashed)")
 	serveCmd.Flags().BoolVar(&setPassphrase, "set-passphrase", false, "Interactively set web UI passphrase")


### PR DESCRIPTION

- Move serveCmd and apiKeyCmd registration from serve.go to root.go
- Consolidate all subcommand registration in root.go init() function
- Fix duplicate 'serve' command appearing in help output

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Centralized CLI subcommand registration in root.go to remove duplication and streamline command wiring. Fixes the duplicate "serve" command shown in help.

- **Refactors**
  - Moved serveCmd and apiKeyCmd registration to root.go init() to keep all subcommands in one place.
  - Cleaned up import ordering in serve.go.

- **Bug Fixes**
  - Eliminated duplicate "serve" command in CLI help output.

<!-- End of auto-generated description by cubic. -->

