### PR TITLE
fix(web): improve API URL construction for production deployment

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -95,7 +95,7 @@ export interface VMAction {
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ||
   (typeof window !== 'undefined' && window.location.hostname !== 'localhost'
-    ? `http://${window.location.hostname}:5550/api`
+    ? `${window.location.protocol}//${window.location.host}/api`
     : "http://localhost:5550/api")
 
 let apiKey: string | null = null
@@ -298,7 +298,7 @@ export const networkAPI = {
   getInterfaces: (): Promise<NetworkInterface[]> => apiRequest("/interfaces"),
   getSystemInterfaces: (): Promise<SystemInterface[]> => apiRequest("/system-interfaces"),
   getVMConnections: (): Promise<VMNetworkConnection[]> => apiRequest("/vm-connections"),
-  createNetwork: (name: string, bridgeName: string): Promise<void> => 
+  createNetwork: (name: string, bridgeName: string): Promise<void> =>
     apiRequest("/networks", {
       method: "POST",
       body: JSON.stringify({ name, bridgeName }),


### PR DESCRIPTION
- Use window.location.protocol instead of hardcoded http://
- Use window.location.host instead of hostname:5550 to preserve port
- Remove trailing whitespace in createNetwork function
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix API base URL construction to use the page’s protocol and host (including port) so production deployments call the correct backend. Prevents HTTPS mixed-content and wrong-port requests; also removes a small whitespace typo in createNetwork.

<!-- End of auto-generated description by cubic. -->

